### PR TITLE
Refine homepage snapshot and rewrite about-page bio

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,13 +38,13 @@
       </figure>
 
       <div class="about__bio">
-        <p class="about__lead">I'm fascinated by the human brain, and that fascination sits at the core of how I design. What motivates behaviour is deeply ingrained and multifaceted.</p>
+        <p class="about__lead">Psychology is what drew me into design. What motivates someone to commit, stay, or walk away is layered, and the answer rarely sits on the surface.</p>
 
-        <p>Nine years in e-commerce digital marketing, spanning subscription, DTC, own brands, healthtech, fashion and beauty, sparked my desire to know customers more deeply. That curiosity led me into UX. Since 2021 I've been a Product Designer at HelloFresh.</p>
+        <p>I came to product design through nine years in e-commerce marketing, working across subscription, DTC, health, fashion, and beauty. Since 2021 I've been a Product Designer at HelloFresh, leading retention work across eight brands.</p>
 
-        <p>With foundational knowledge of user patterns across these industries, I bring a holistic perspective to every project. By understanding user needs and the broader ecosystem a product lives in, the problem becomes clear.</p>
+        <p>I'm a generalist who's most useful at the seams between teams. I've spent the last few years bridging design, engineering, and design systems, often picking up projects mid-flight and shipping them with the people already there.</p>
 
-        <p>When I'm not designing, you'll find me hiking in the mountains, digging for vintage treasures, or picking up knitting stitches on the couch.</p>
+        <p>Off the clock: long hikes, vintage hunting, and slowly improving my knitting.</p>
 
         <ul class="pills about__pills">
           <li><button type="button" class="pill copy-email" data-email="amanda.r.low@outlook.com" data-default="Email" data-copied="Copied">Email</button></li>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <span><b>Based in</b> Berlin</span>
       <span><b>Working in</b> EN, DE</span>
       <span><b>Currently</b> Product Designer, HelloFresh</span>
-      <span><b>Experience</b> 5 years design, 9 years marketing</span>
+      <span><b>Focus</b> Retention, multi-brand systems</span>
     </p>
   </div>
 


### PR DESCRIPTION
## Summary

Small copy follow-up to the codex redesign (#2).

- Homepage snapshot: replaces `Experience: 5 years design, 9 years marketing` with `Focus: Retention, multi-brand systems`. The case studies already prove level, and the Focus framing positions the portfolio thesis without inviting tenure comparison.
- About-page bio rewritten in four tighter paragraphs: psychology lead, career timeline, working style, hobbies. Drops generic phrasing ("holistic perspective", "broader ecosystem") and a redundant say/do gap reference.

## Test plan

- [ ] Homepage snapshot reads `Based in Berlin · Working in EN, DE · Currently Product Designer, HelloFresh · Focus Retention, multi-brand systems`
- [ ] About bio reads in first person, four paragraphs
- [ ] Snapshot still spans the same content width as the masthead

🤖 Generated with [Claude Code](https://claude.com/claude-code)